### PR TITLE
Fix default value for spiders setting

### DIFF
--- a/public/rsl-s2-tracker.html
+++ b/public/rsl-s2-tracker.html
@@ -59,7 +59,7 @@
             <span class="centerrow-subbox-column">
                 <span class="progressive toggle-off" id="songs">Songs</span>
                 <span class="progressive toggle-off" id="shops">Shops</span>
-                <span class="progressive toggle-off" id="spiders">Spiders</span>
+                <span class="progressive toggle-off" id="spiders">Skulltulas</span>
                 <span class="progressive toggle-off" id="scrubs">Scrubs</span>
             </span>
             <span class="centerrow-subbox-column">


### PR DESCRIPTION
This fixes a bug where the “Skulltulas” setting text starts out as “Spiders” and remains disabled when clicked for the first time.